### PR TITLE
[Chore] Enable wayland socket

### DIFF
--- a/xyz.armcord.ArmCord.yml
+++ b/xyz.armcord.ArmCord.yml
@@ -13,6 +13,8 @@ separate-locales: false
 finish-args: # We aren't trying to get tray icons working here for several reasons, mainly I'm too stressed to figure them out. -Oro
   - --socket=pulseaudio
   - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc
   - --share=network
 # Potential security vulnerability, but the people want tray icons.


### PR DESCRIPTION
Based on [#359](https://github.com/ArmCord/ArmCord/issues/359).

After testing the latest flatpak, screen sharing wouldn't work unless the wayland socket was enabled. This was tested on an Nvidia GPU meaning AMD and/or Intel GPUs shouldn't have any issues.

Additionally enabled the x11 fallback socket 'just in case'.

