### PR TITLE
Drop kde own name

### DIFF
--- a/xyz.armcord.ArmCord.yml
+++ b/xyz.armcord.ArmCord.yml
@@ -15,8 +15,6 @@ finish-args: # We aren't trying to get tray icons working here for several reaso
   - --socket=x11
   - --share=ipc
   - --share=network
-# Potential security vulnerability, but the people want tray icons.
-  - --own-name=org.kde.*
   - --talk-name=org.freedesktop.Notifications # Discord push notifs
   - --device=all # Needed for GPU acceleration and the webcam
   - --filesystem=xdg-videos:ro

--- a/xyz.armcord.ArmCord.yml
+++ b/xyz.armcord.ArmCord.yml
@@ -16,6 +16,7 @@ finish-args: # We aren't trying to get tray icons working here for several reaso
   - --share=ipc
   - --share=network
   - --talk-name=org.freedesktop.Notifications # Discord push notifs
+  - --talk-name=org.kde.StatusNotifierWatcher # Tray functionalities on KDE
   - --device=all # Needed for GPU acceleration and the webcam
   - --filesystem=xdg-videos:ro
   - --filesystem=xdg-pictures:ro


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 26.1.0
https://github.com/ArmCord/ArmCord/blob/c717b848531e76e92e90c35ab85f9917b1529991/package.json#L39