### PR TITLE
Issue workaround with discord rich presence not found

### DIFF
--- a/minerals/startarmcord
+++ b/minerals/startarmcord
@@ -43,3 +43,4 @@ fi
 FLAGS+=(--enable-features="${FEATURES}")
 echo "Passing the following arguments to Electron:" "${FLAGS[@]}"
 zypak-wrapper /app/bin/armcord/armcord "${FLAGS[@]}" "$@"
+kill -SIGTERM $socat_pid

--- a/minerals/startarmcord
+++ b/minerals/startarmcord
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+socat $SOCAT_ARGS \
+    UNIX-LISTEN:$XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-0,forever,fork \
+    UNIX-CONNECT:$XDG_RUNTIME_DIR/discord-ipc-0 \
+    &
+socat_pid=$!
+
 # Set FEATURES to what goes after --enable-features; for example, UseSkiaRenderer,WebRTCPipeWireCapturer,etc,etc will then get turned into --enable-features=UseSkiaRenderer,WebRTCPipeWireCapturer,etc,etc.
 FEATURES="UseSkiaRenderer"
 TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-xyz.armcord.ArmCord}"

--- a/xyz.armcord.ArmCord.yml
+++ b/xyz.armcord.ArmCord.yml
@@ -32,7 +32,7 @@ modules:
         sha256: 6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82
         x-checker-data:
           type: anitya
-          project-id: 4848
+          project-id: 4847
           url-template: http://www.dest-unreach.org/socat/download/socat-$version.tar.gz
 
   - name: minerals
@@ -69,12 +69,3 @@ modules:
         x-checker-data:
           type: electron-updater
           url: https://github.com/ArmCord/ArmCord/releases/latest/download/latest-linux-arm64.yml
-
-      - type: file
-        url: http://www.dest-unreach.org/socat/download/socat-1.8.0.0.tar.gz
-        sha256: 6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82
-        only-arches: [aarch64]
-        x-checker-data:
-          type: anitya
-          project-id: 4848
-          url-template: http://www.dest-unreach.org/socat/download/socat-$version.tar.gz

--- a/xyz.armcord.ArmCord.yml
+++ b/xyz.armcord.ArmCord.yml
@@ -18,12 +18,23 @@ finish-args: # We aren't trying to get tray icons working here for several reaso
   - --talk-name=org.freedesktop.Notifications # Discord push notifs
   - --talk-name=org.kde.StatusNotifierWatcher # Tray functionalities on KDE
   - --device=all # Needed for GPU acceleration and the webcam
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-videos:ro
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons # This is used to show the correct cursor on Wayland
 
 modules:
+  - name: socat
+    sources:
+      - type: archive
+        url: http://www.dest-unreach.org/socat/download/socat-1.8.0.0.tar.gz
+        sha256: 6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82
+        x-checker-data:
+          type: anitya
+          project-id: 4848
+          url-template: http://www.dest-unreach.org/socat/download/socat-$version.tar.gz
+
   - name: minerals
     buildsystem: simple
     build-commands:
@@ -59,3 +70,11 @@ modules:
           type: electron-updater
           url: https://github.com/ArmCord/ArmCord/releases/latest/download/latest-linux-arm64.yml
 
+      - type: file
+        url: http://www.dest-unreach.org/socat/download/socat-1.8.0.0.tar.gz
+        sha256: 6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82
+        only-arches: [aarch64]
+        x-checker-data:
+          type: anitya
+          project-id: 4848
+          url-template: http://www.dest-unreach.org/socat/download/socat-$version.tar.gz


### PR DESCRIPTION
socat original socket file to `$xdg_runtime_dir/app/com.discord.Discordapp` so it could be read by flatpak apps that using it. Copying what discord flathub is doing.